### PR TITLE
Specify stricter dependency on python-daemon, fixes #286

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,5 +4,5 @@ glob2==0.3
 mosquitto>=1.1
 msgpack-pure>=0.1.3
 pika>=0.9.12
-python-daemon>=1.5.2
+python-daemon>=1.5.2,<=1.6.1
 redis>=2.7.5


### PR DESCRIPTION
Should fix #286, since installation seems to be broken with python-daemon 2.x.x.

I specified <= 1.6.1, since up to that version seems to have been working.