### PR TITLE
Adding support for sqs queues in different accounts

### DIFF
--- a/beaver/config.py
+++ b/beaver/config.py
@@ -82,6 +82,7 @@ class BeaverConfig():
             'sqs_aws_secret_key': '',
             'sqs_aws_region': 'us-east-1',
             'sqs_aws_queue': '',
+            'sqs_aws_queue_owner_acct_id': '',
             'tcp_host': '127.0.0.1',
             'tcp_port': '9999',
             'tcp_ssl_enabled': '0',

--- a/beaver/transports/sqs_transport.py
+++ b/beaver/transports/sqs_transport.py
@@ -16,6 +16,7 @@ class SqsTransport(BaseTransport):
         self._secret_key = beaver_config.get('sqs_aws_secret_key')
         self._region = beaver_config.get('sqs_aws_region')
         self._queue_name = beaver_config.get('sqs_aws_queue')
+        self._queue_owner_acct_id = beaver_config.get('sqs_aws_queue_owner_acct_id')
 
         try:
             if self._access_key is None and self._secret_key is None:
@@ -29,7 +30,11 @@ class SqsTransport(BaseTransport):
                 self._logger.warn('Unable to connect to AWS - check your AWS credentials')
                 raise TransportException('Unable to connect to AWS - check your AWS credentials')
 
-            self._queue = self._connection.get_queue(self._queue_name)
+            if self._queue_owner_acct_id is None:
+                self._queue = self._connection.get_queue(self._queue_name)
+            else:
+                self._queue = self._connection.get_queue(self._queue_name, 
+                                                         owner_acct_id=self._queue_owner_acct_id)
 
             if self._queue is None:
                 raise TransportException('Unable to access queue with name {0}'.format(self._queue_name))

--- a/docs/user/usage.rst
+++ b/docs/user/usage.rst
@@ -70,6 +70,7 @@ Beaver can optionally get data from a ``configfile`` using the ``-c`` flag. This
 * sqs_aws_secret_key: Can be left blank to use IAM Roles or AWS_SECRET_ACCESS_KEY environment variable (see: https://github.com/boto/boto#getting-started-with-boto)
 * sqs_aws_region: Default ``us-east-1``. AWS Region
 * sqs_aws_queue: SQS queue (must exist)
+* sqs_aws_queue_owner_acct_id: Optional. Defaults ``None``. Account ID or Principal allowed to write to queue
 * tcp_host: Default ``127.0.0.1``. TCP Host
 * tcp_port: Default ``9999``. TCP Port
 * udp_host: Default ``127.0.0.1``. UDP Host


### PR DESCRIPTION
This should enable beaver to log to sqs queues in another account.