### PR TITLE
Initial kafka transport impl

### DIFF
--- a/beaver/config.py
+++ b/beaver/config.py
@@ -53,6 +53,15 @@ class BeaverConfig():
         }
 
         self._main_defaults = {
+            'kafka_client_id': os.environ.get('KAFKA_CLIENT_ID', 'beaver-kafka'),
+            'kafka_hosts': os.environ.get('KAFKA_HOSTS', 'localhost:9092'),
+            'kafka_async': os.environ.get('KAFKA_ASYNC', True),
+            'kafka_topic': os.environ.get('KAFKA_TOPIC', 'logstash-topic'),
+            'kafka_key': os.environ.get('KAFKA_KEY'),
+            'kafka_codec': os.environ.get('KAFKA_CODEC'),
+            'kafka_ack_timeout': os.environ.get('KAFKA_ACK_TIMEOUT', 2000),
+            'kafka_batch_n': os.environ.get('KAFKA_BATCH_N', 10),
+            'kafka_batch_t': os.environ.get('KAFKA_BATCH_T', 10),
             'mqtt_clientid': 'mosquitto',
             'mqtt_host': 'localhost',
             'mqtt_port': '1883',
@@ -290,6 +299,9 @@ class BeaverConfig():
                 'wait_timeout',
                 'zeromq_hwm',
                 'logstash_version',
+                'kafka_batch_n',
+                'kafka_batch_t',
+                'kafka_ack_timeout'
             ]
             for key in require_int:
                 if config[key] is not None:

--- a/beaver/tests/servers/0.8.2.0/resources/kafka.properties
+++ b/beaver/tests/servers/0.8.2.0/resources/kafka.properties
@@ -1,0 +1,118 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# see kafka.server.KafkaConfig for additional details and defaults
+
+############################# Server Basics #############################
+
+# The id of the broker. This must be set to a unique integer for each broker.
+broker.id={broker_id}
+
+############################# Socket Server Settings #############################
+
+# The port the socket server listens on
+port={port}
+
+# Hostname the broker will bind to. If not set, the server will bind to all interfaces
+host.name={host}
+
+# Hostname the broker will advertise to producers and consumers. If not set, it uses the
+# value for "host.name" if configured.  Otherwise, it will use the value returned from
+# java.net.InetAddress.getCanonicalHostName().
+#advertised.host.name=<hostname routable by clients>
+
+# The port to publish to ZooKeeper for clients to use. If this is not set,
+# it will publish the same port that the broker binds to.
+#advertised.port=<port accessible by clients>
+
+# The number of threads handling network requests
+num.network.threads=2
+
+# The number of threads doing disk I/O
+num.io.threads=8
+
+# The send buffer (SO_SNDBUF) used by the socket server
+socket.send.buffer.bytes=1048576
+
+# The receive buffer (SO_RCVBUF) used by the socket server
+socket.receive.buffer.bytes=1048576
+
+# The maximum size of a request that the socket server will accept (protection against OOM)
+socket.request.max.bytes=104857600
+
+
+############################# Log Basics #############################
+
+# A comma seperated list of directories under which to store log files
+log.dirs={tmp_dir}/data
+
+# The default number of log partitions per topic. More partitions allow greater
+# parallelism for consumption, but this will also result in more files across
+# the brokers.
+num.partitions={partitions}
+default.replication.factor={replicas}
+
+############################# Log Flush Policy #############################
+
+# Messages are immediately written to the filesystem but by default we only fsync() to sync
+# the OS cache lazily. The following configurations control the flush of data to disk.
+# There are a few important trade-offs here:
+#    1. Durability: Unflushed data may be lost if you are not using replication.
+#    2. Latency: Very large flush intervals may lead to latency spikes when the flush does occur as there will be a lot of data to flush.
+#    3. Throughput: The flush is generally the most expensive operation, and a small flush interval may lead to exceessive seeks.
+# The settings below allow one to configure the flush policy to flush data after a period of time or
+# every N messages (or both). This can be done globally and overridden on a per-topic basis.
+
+# The number of messages to accept before forcing a flush of data to disk
+#log.flush.interval.messages=10000
+
+# The maximum amount of time a message can sit in a log before we force a flush
+#log.flush.interval.ms=1000
+
+############################# Log Retention Policy #############################
+
+# The following configurations control the disposal of log segments. The policy can
+# be set to delete segments after a period of time, or after a given size has accumulated.
+# A segment will be deleted whenever *either* of these criteria are met. Deletion always happens
+# from the end of the log.
+
+# The minimum age of a log file to be eligible for deletion
+log.retention.hours=168
+
+# A size-based retention policy for logs. Segments are pruned from the log as long as the remaining
+# segments don't drop below log.retention.bytes.
+#log.retention.bytes=1073741824
+
+# The maximum size of a log segment file. When this size is reached a new log segment will be created.
+log.segment.bytes=536870912
+
+# The interval at which log segments are checked to see if they can be deleted according
+# to the retention policies
+log.retention.check.interval.ms=60000
+
+# By default the log cleaner is disabled and the log retention policy will default to just delete segments after their retention expires.
+# If log.cleaner.enable=true is set the cleaner will be enabled and individual logs can then be marked for log compaction.
+log.cleaner.enable=false
+
+############################# Zookeeper #############################
+
+# Zookeeper connection string (see zookeeper docs for details).
+# This is a comma separated host:port pairs, each corresponding to a zk
+# server. e.g. "127.0.0.1:3000,127.0.0.1:3001,127.0.0.1:3002".
+# You can also append an optional chroot string to the urls to specify the
+# root directory for all kafka znodes.
+zookeeper.connect={zk_host}:{zk_port}/{zk_chroot}
+
+# Timeout in ms for connecting to zookeeper
+zookeeper.connection.timeout.ms=1000000

--- a/beaver/tests/servers/0.8.2.0/resources/log4j.properties
+++ b/beaver/tests/servers/0.8.2.0/resources/log4j.properties
@@ -1,0 +1,24 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+log4j.rootLogger=INFO, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n
+
+log4j.logger.kafka=DEBUG, stdout
+log4j.logger.org.I0Itec.zkclient.ZkClient=INFO, stdout
+log4j.logger.org.apache.zookeeper=INFO, stdout

--- a/beaver/tests/servers/0.8.2.0/resources/zookeeper.properties
+++ b/beaver/tests/servers/0.8.2.0/resources/zookeeper.properties
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# the directory where the snapshot is stored.
+dataDir={tmp_dir}
+# the port at which the clients will connect
+clientPort={port}
+clientPortAddress={host}
+# disable the per-ip limit on the number of connections since this is a non-production config
+maxClientCnxns=0

--- a/beaver/tests/servers/dist/.gitignore
+++ b/beaver/tests/servers/dist/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/beaver/tests/service.py
+++ b/beaver/tests/service.py
@@ -1,0 +1,110 @@
+import logging
+import re
+import select
+import subprocess
+import threading
+import time
+
+__all__ = [
+    'ExternalService',
+    'SpawnedService',
+
+]
+
+class ExternalService(object):
+    def __init__(self, host, port):
+        logging.info("Using already running service at %s:%d", host, port)
+        self.host = host
+        self.port = port
+
+    def open(self):
+        pass
+
+    def close(self):
+        pass
+
+
+class SpawnedService(threading.Thread):
+    def __init__(self, args=None, env=None):
+        threading.Thread.__init__(self)
+
+        if args is None:
+            raise TypeError("args parameter is required")
+        self.args = args
+        self.env = env
+        self.captured_stdout = []
+        self.captured_stderr = []
+
+        self.should_die = threading.Event()
+
+    def run(self):
+        self.run_with_handles()
+
+    def run_with_handles(self):
+        self.child = subprocess.Popen(
+            self.args,
+            env=self.env,
+            bufsize=1,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE)
+        alive = True
+
+        while True:
+            (rds, _, _) = select.select([self.child.stdout, self.child.stderr], [], [], 1)
+
+            if self.child.stdout in rds:
+                line = self.child.stdout.readline()
+                self.captured_stdout.append(line.decode('utf-8'))
+
+            if self.child.stderr in rds:
+                line = self.child.stderr.readline()
+                self.captured_stderr.append(line.decode('utf-8'))
+
+            if self.should_die.is_set():
+                self.child.terminate()
+                alive = False
+
+            poll_results = self.child.poll()
+            if poll_results is not None:
+                if not alive:
+                    break
+                else:
+                    self.dump_logs()
+                    raise RuntimeError("Subprocess has died. Aborting. (args=%s)" % ' '.join(str(x) for x in self.args))
+
+    def dump_logs(self):
+        logging.critical('stderr')
+        for line in self.captured_stderr:
+            logging.critical(line.rstrip())
+
+        logging.critical('stdout')
+        for line in self.captured_stdout:
+            logging.critical(line.rstrip())
+
+    def wait_for(self, pattern, timeout=30):
+        t1 = time.time()
+        while True:
+            t2 = time.time()
+            if t2 - t1 >= timeout:
+                try:
+                    self.child.kill()
+                except:
+                    logging.exception("Received exception when killing child process")
+                self.dump_logs()
+
+                raise RuntimeError("Waiting for %r timed out after %d seconds" % (pattern, timeout))
+
+            if re.search(pattern, '\n'.join(self.captured_stdout), re.IGNORECASE) is not None:
+                logging.info("Found pattern %r in %d seconds via stdout", pattern, (t2 - t1))
+                return
+            if re.search(pattern, '\n'.join(self.captured_stderr), re.IGNORECASE) is not None:
+                logging.info("Found pattern %r in %d seconds via stderr", pattern, (t2 - t1))
+                return
+            time.sleep(0.1)
+
+    def start(self):
+        threading.Thread.start(self)
+
+    def stop(self):
+        self.should_die.set()
+        self.join()

--- a/beaver/tests/test_kafka_transport.py
+++ b/beaver/tests/test_kafka_transport.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+import mock
+import unittest
+import tempfile
+import logging
+
+
+import beaver
+from beaver.config import BeaverConfig
+from beaver.transports import create_transport
+
+from beaver.unicode_dammit import unicode_dammit
+
+from fixtures import Fixture, ZookeeperFixture, KafkaFixture
+
+try:
+    from beaver.transports.kafka_transport import KafkaTransport
+    skip = False
+except ImportError, e:
+    if e.message == 'No module named kafka':
+        skip = True
+    else:
+        raise
+
+
+@unittest.skipIf(skip, 'kafka not installed')
+class KafkaTests(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.logger = logging.getLogger(__name__)
+
+        empty_conf = tempfile.NamedTemporaryFile(delete=True)
+        cls.beaver_config = BeaverConfig(mock.Mock(config=empty_conf.name))
+
+        output_file = Fixture.download_official_distribution()
+        Fixture.extract_distribution(output_file)
+        cls.zk = ZookeeperFixture.instance()
+        cls.server = KafkaFixture.instance(0, cls.zk.host, cls.zk.port)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.close()
+        cls.zk.close()
+
+    def test_builtin_kafka(cls):
+        cls.beaver_config.set('transport', 'kafka')
+        cls.beaver_config.set('logstash_version', 1)
+        cls.beaver_config.set('kafka_hosts', cls.server.host + ":" + str(cls.server.port))
+
+        transport = create_transport(cls.beaver_config, logger=cls.logger)
+        data = {}
+        lines = ['log1\n', 'log2\n']
+        new_lines = []
+        for line in lines:
+            message = unicode_dammit(line)
+            if len(message) == 0:
+                continue
+            new_lines.append(message)
+        data['lines'] = new_lines
+        data['fields'] = []
+        transport.callback("test.log", **data)
+        transport.interrupt()
+        cls.assertIsInstance(transport, beaver.transports.kafka_transport.KafkaTransport)
+
+
+

--- a/beaver/tests/test_transport_config.py
+++ b/beaver/tests/test_transport_config.py
@@ -25,6 +25,11 @@ with mock.patch('pika.adapters.BlockingConnection', autospec=True) as mock_pika:
             empty_conf = tempfile.NamedTemporaryFile(delete=True)
             return BeaverConfig(mock.Mock(config=empty_conf.name, **kwargs))
 
+        def test_builtin_kafka(self):
+            beaver_config = self._get_config(transport='kafka')
+            transport = create_transport(beaver_config, logger=self.logger)
+            self.assertIsInstance(transport, beaver.transports.kafka_transport.KafkaTransport)
+
         @mock.patch('pika.adapters.BlockingConnection', mock_pika)
         def test_builtin_rabbitmq(self):
             beaver_config = self._get_config(transport='rabbitmq')

--- a/beaver/tests/test_transport_config.py
+++ b/beaver/tests/test_transport_config.py
@@ -25,11 +25,6 @@ with mock.patch('pika.adapters.BlockingConnection', autospec=True) as mock_pika:
             empty_conf = tempfile.NamedTemporaryFile(delete=True)
             return BeaverConfig(mock.Mock(config=empty_conf.name, **kwargs))
 
-        def test_builtin_kafka(self):
-            beaver_config = self._get_config(transport='kafka')
-            transport = create_transport(beaver_config, logger=self.logger)
-            self.assertIsInstance(transport, beaver.transports.kafka_transport.KafkaTransport)
-
         @mock.patch('pika.adapters.BlockingConnection', mock_pika)
         def test_builtin_rabbitmq(self):
             beaver_config = self._get_config(transport='rabbitmq')

--- a/beaver/transports/kafka_transport.py
+++ b/beaver/transports/kafka_transport.py
@@ -18,27 +18,31 @@ class KafkaTransport(BaseTransport):
         for key in config_to_store:
             self._kafka_config[key] = beaver_config.get('kafka_' + key)
 
-        self._client = KafkaClient(self._kafka_config['hosts'], self._kafka_config['client_id'])
-        self._key = self._kafka_config['key']
+        try:
+            self._client = KafkaClient(self._kafka_config['hosts'], self._kafka_config['client_id'])
+            self._key = self._kafka_config['key']
 
-        if self._key is None:
-            self._prod = SimpleProducer(self._client, async=self._kafka_config['async'],
-                                    req_acks=SimpleProducer.ACK_AFTER_LOCAL_WRITE,
-                                    ack_timeout=self._kafka_config['ack_timeout'],
-                                    codec=self._kafka_config['codec'],
-                                    batch_send=True,
-                                    batch_send_every_n=self._kafka_config['batch_n'],
-                                    batch_send_every_t=self._kafka_config['batch_t'])
-        else:
-            self._prod = KeyedProducer(self._client, async=self._kafka_config['async'],
-                                    req_acks=SimpleProducer.ACK_AFTER_LOCAL_WRITE,
-                                    ack_timeout=self._kafka_config['ack_timeout'],
-                                    codec=self._kafka_config['codec'],
-                                    batch_send=True,
-                                    batch_send_every_n=self._kafka_config['batch_n'],
-                                    batch_send_every_t=self._kafka_config['batch_t'])
+            if self._key is None:
+                self._prod = SimpleProducer(self._client, async=self._kafka_config['async'],
+                                        req_acks=SimpleProducer.ACK_AFTER_LOCAL_WRITE,
+                                        ack_timeout=self._kafka_config['ack_timeout'],
+                                        codec=self._kafka_config['codec'],
+                                        batch_send=True,
+                                        batch_send_every_n=self._kafka_config['batch_n'],
+                                        batch_send_every_t=self._kafka_config['batch_t'])
+            else:
+                self._prod = KeyedProducer(self._client, async=self._kafka_config['async'],
+                                        req_acks=SimpleProducer.ACK_AFTER_LOCAL_WRITE,
+                                        ack_timeout=self._kafka_config['ack_timeout'],
+                                        codec=self._kafka_config['codec'],
+                                        batch_send=True,
+                                        batch_send_every_n=self._kafka_config['batch_n'],
+                                        batch_send_every_t=self._kafka_config['batch_t'])
 
-        self._is_valid = True;
+            self._is_valid = True;
+            
+        except Exception, e:
+            raise TransportException(e.message)
 
 
     def callback(self, filename, lines, **kwargs):

--- a/beaver/transports/kafka_transport.py
+++ b/beaver/transports/kafka_transport.py
@@ -20,6 +20,7 @@ class KafkaTransport(BaseTransport):
 
         try:
             self._client = KafkaClient(self._kafka_config['hosts'], self._kafka_config['client_id'])
+            self._client.ensure_topic_exists(self._kafka_config['topic'])
             self._key = self._kafka_config['key']
 
             if self._key is None:
@@ -40,7 +41,7 @@ class KafkaTransport(BaseTransport):
                                         batch_send_every_t=self._kafka_config['batch_t'])
 
             self._is_valid = True;
-            
+
         except Exception, e:
             raise TransportException(e.message)
 

--- a/beaver/transports/kafka_transport.py
+++ b/beaver/transports/kafka_transport.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+from kafka import SimpleProducer, KeyedProducer, KafkaClient
+
+from beaver.transports.base_transport import BaseTransport
+from beaver.transports.exception import TransportException
+
+class KafkaTransport(BaseTransport):
+
+    def __init__(self, beaver_config, logger=None):
+        super(KafkaTransport, self).__init__(beaver_config, logger=logger)
+
+        self._kafka_config = {}
+        config_to_store = [
+            'client_id', 'hosts', 'async', 'topic', 'key',
+            'ack_timeout', 'codec', 'batch_n', 'batch_t'
+        ]
+
+        for key in config_to_store:
+            self._kafka_config[key] = beaver_config.get('kafka_' + key)
+
+        self._client = KafkaClient(self._kafka_config['hosts'], self._kafka_config['client_id'])
+        self._key = self._kafka_config['key']
+
+        if self._key is None:
+            self._prod = SimpleProducer(self._client, async=self._kafka_config['async'],
+                                    req_acks=SimpleProducer.ACK_AFTER_LOCAL_WRITE,
+                                    ack_timeout=self._kafka_config['ack_timeout'],
+                                    codec=self._kafka_config['codec'],
+                                    batch_send=True,
+                                    batch_send_every_n=self._kafka_config['batch_n'],
+                                    batch_send_every_t=self._kafka_config['batch_t'])
+        else:
+            self._prod = KeyedProducer(self._client, async=self._kafka_config['async'],
+                                    req_acks=SimpleProducer.ACK_AFTER_LOCAL_WRITE,
+                                    ack_timeout=self._kafka_config['ack_timeout'],
+                                    codec=self._kafka_config['codec'],
+                                    batch_send=True,
+                                    batch_send_every_n=self._kafka_config['batch_n'],
+                                    batch_send_every_t=self._kafka_config['batch_t'])
+
+        self._is_valid = True;
+
+
+    def callback(self, filename, lines, **kwargs):
+        """publishes lines one by one to the given topic"""
+        timestamp = self.get_timestamp(**kwargs)
+        if kwargs.get('timestamp', False):
+            del kwargs['timestamp']
+
+        for line in lines:
+            try:
+                import warnings
+                with warnings.catch_warnings():
+                    warnings.simplefilter('error')
+                    #produce message
+                    if self._key is None:
+                        response = self._prod.send_messages(self._kafka_config['topic'], self.format(filename, line, timestamp, **kwargs))
+                    else:
+                        response = self._prod.send_messages(self._kafka_config['topic'], self._key, self.format(filename, line, timestamp, **kwargs))
+
+                    if response:
+                        if response[0].error:
+                            self._logger.info('message error: {0}'.format(response[0].error))
+                            self._logger.info('message offset: {0}'.format(response[0].offset))
+
+            except Exception as e:
+                try:
+                    self._logger.error('Exception caught sending message/s : ' + str(e))
+                    raise TransportException(e.strerror)
+                except AttributeError:
+                    raise TransportException('Unspecified exception encountered')  # TRAP ALL THE THINGS!
+
+    def interrupt(self):
+        if self._prod:
+            self._prod.stop()
+        if self._client:
+            self._client.close()
+
+    def unhandled(self):
+        return True

--- a/beaver/utils.py
+++ b/beaver/utils.py
@@ -44,7 +44,7 @@ def parse_args():
     parser.add_argument('-l', '--logfile', '-o', '--output', help='file to pipe output to (in addition to stdout)', default=None, dest='output')
     parser.add_argument('-p', '--path', help='path to log files', default=None, dest='path')
     parser.add_argument('-P', '--pid', help='path to pid file', default=None, dest='pid')
-    parser.add_argument('-t', '--transport', help='log transport method', dest='transport', default=None, choices=['mqtt', 'rabbitmq', 'redis', 'sqs', 'stdout', 'tcp', 'udp', 'zmq', 'http'])
+    parser.add_argument('-t', '--transport', help='log transport method', dest='transport', default=None, choices=['kafka', 'mqtt', 'rabbitmq', 'redis', 'sqs', 'stdout', 'tcp', 'udp', 'zmq', 'http'])
     parser.add_argument('-e', '--experimental', help='use experimental version of beaver', dest='experimental', default=False, action='store_true')
     parser.add_argument('-v', '--version', help='output version and quit', dest='version', default=False, action='store_true')
     parser.add_argument('--fqdn', help='use the machine\'s FQDN for source_host', dest='fqdn', default=False, action='store_true')

--- a/docs/user/usage.rst
+++ b/docs/user/usage.rst
@@ -10,7 +10,7 @@ usage::
     beaver [-h] [-c CONFIG] [-C CONFD_PATH] [-d] [-D] [-f FILES [FILES ...]]
            [-F {json,msgpack,raw,rawjson,string}] [-H HOSTNAME] [-m {bind,connect}]
            [-l OUTPUT] [-p PATH] [-P PID]
-           [-t {mqtt,rabbitmq,redis,sqs,stdout,tcp,udp,zmq}] [-v] [--fqdn]
+           [-t {kafka,mqtt,rabbitmq,redis,sqs,stdout,tcp,udp,zmq}] [-v] [--fqdn]
 
 optional arguments::
 
@@ -33,7 +33,7 @@ optional arguments::
                           file to pipe output to (in addition to stdout)
     -p PATH, --path PATH  path to log files
     -P PID, --pid PID     path to pid file
-    -t {mqtt,rabbitmq,redis,stdout,tcp,udp,zmq}, --transport {mqtt,rabbitmq,redis,sqs,stdout,tcp,udp,zmq}
+    -t {kafka,mqtt,rabbitmq,redis,stdout,tcp,udp,zmq}, --transport {kafka,mqtt,rabbitmq,redis,sqs,stdout,tcp,udp,zmq}
                           log transport method
     -v, --version         output version and quit
     --fqdn                use the machine's FQDN for source_host
@@ -43,6 +43,15 @@ Configuration File Options
 
 Beaver can optionally get data from a ``configfile`` using the ``-c`` flag. This file is in ``ini`` format. Global configuration will be under the ``beaver`` stanza. The following are global beaver configuration keys with their respective meanings:
 
+* kafka_client_id: Default ``beaver-kafka``. Kafka client id
+* kafka_hosts: Default ``localhost:9092``. Seed list of hosts (host:port)separated by commas for kafka cluster
+* kafka_async: Default ``True``.
+* kafka_topic: Default ``logstash-topic``
+* kafka_key: Optional. Defaults ``None``. Target specific partition
+* kafka_codec: Optional. Defaults ``None``. GZIP supported with 0x01. SNAPPY requires to install python-snappy anbd use codec = 0x02
+* kafka_ack_timeout: Default ``2000``. Acknowledge timeout
+* kafka_batch_n: Default ``10``. Batch log message size
+* kafka_batch_t: Default ``10``. Batch log message timeout
 * mqtt_host: Default ``localhost``. Host for mosquitto
 * mqtt_port: Default ``1883``. Port for mosquitto
 * mqtt_clientid: Default ``mosquitto``. Mosquitto client id

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,7 @@
 boto>=2.8.0
 conf_d>=0.0.4
 glob2==0.3
+kafka-python>=0.9.3
 mosquitto>=1.1
 msgpack-pure>=0.1.3
 pika>=0.9.12

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,3 +1,4 @@
 fakeredis>=0.4.1
 mock
 nose
+six

--- a/setup.py
+++ b/setup.py
@@ -79,5 +79,5 @@ setup(
                 open('CHANGES.rst').read(),
     tests_require=open('requirements/tests.txt').readlines(),
     test_suite='nose.collector',
-    install_requires=requirements,
+    install_requires=requirements, requires=['six']
 )


### PR DESCRIPTION
Initial Kafka transport impl. Uses kafka-python module. Tested with an out of the box kafka server. Supported config options:

* kafka_client_id: Default ``beaver-kafka``. Kafka client id
* kafka_hosts: Default ``localhost:9092``. Seed list of hosts (host:port)separated by commas for kafka cluster
* kafka_async: Default ``True``.
* kafka_topic: Default ``logstash-topic``
* kafka_key: Optional. Defaults ``None``. Target specific partition
* kafka_codec: Optional. Defaults ``None``. GZIP supported with 0x01. SNAPPY requires to install python-snappy anbd use codec = 0x02
* kafka_ack_timeout: Default ``2000``. Acknowledge timeout
* kafka_batch_n: Default ``10``. Batch log message size
* kafka_batch_t: Default ``10``. Batch log message timeout