### PR TITLE
Add channel support to Redis transport

### DIFF
--- a/beaver/config.py
+++ b/beaver/config.py
@@ -87,6 +87,7 @@ class BeaverConfig():
             'rabbitmq_delivery_mode': 1,
             'redis_url': os.environ.get('REDIS_URL', 'redis://localhost:6379/0'),
             'redis_namespace': os.environ.get('REDIS_NAMESPACE', 'logstash:beaver'),
+            'redis_data_type': os.environ.get('REDIS_DATA_TYPE', 'list'),
             'redis_password': '',
             'sqs_aws_access_key': '',
             'sqs_aws_secret_key': '',

--- a/beaver/transports/redis_transport.py
+++ b/beaver/transports/redis_transport.py
@@ -84,19 +84,18 @@ class RedisTransport(BaseTransport):
 
         pipeline = server['redis'].pipeline(transaction=False)
 
+        if data_type == 'list':
+            data_type_method = pipeline.rpush
+        elif data_type == 'channel':
+            data_type_method = pipeline.publish
+        else:
+            raise TransportException('Unknown Redis data type')
+
         for line in lines:
-            if data_type == 'list':
-                pipeline.rpush(
-                    namespace,
-                    self.format(filename, line, timestamp, **kwargs)
-                )
-            elif data_type == 'channel':
-                pipeline.publish(
-                    namespace,
-                    self.format(filename, line, timestamp, **kwargs)
-                )
-            else:
-                raise TransportException('Unknown Redis data type')
+            data_type_method(
+                namespace,
+                self.format(filename, line, timestamp, **kwargs)
+            )
 
         try:
             pipeline.execute()

--- a/docs/user/usage.rst
+++ b/docs/user/usage.rst
@@ -75,6 +75,7 @@ Beaver can optionally get data from a ``configfile`` using the ``-c`` flag. This
 * rabbitmq_delivery_mode: Default ``1``. Message deliveryMode. 1: non persistent 2: persistent
 * redis_url: Default ``redis://localhost:6379/0``. Comma separated redis URLs
 * redis_namespace: Default ``logstash:beaver``. Redis key namespace
+* redis_data_type: Default ``list``, but can also be ``channel``. Redis data type used for transporting log messages
 * sqs_aws_access_key: Can be left blank to use IAM Roles or AWS_ACCESS_KEY_ID environment variable (see: https://github.com/boto/boto#getting-started-with-boto)
 * sqs_aws_secret_key: Can be left blank to use IAM Roles or AWS_SECRET_ACCESS_KEY environment variable (see: https://github.com/boto/boto#getting-started-with-boto)
 * sqs_aws_region: Default ``us-east-1``. AWS Region


### PR DESCRIPTION
This changeset adds support for publishing log entries to a Redis channel, which is also supported by Logstash's Redis input.

Beaver configuration files can now supply a `redis_data_type` key. Valid values for this key are `list` and `channel`. If left unset, the default is `list`.

Attempts to resolve #266.