### PR TITLE
#323 RabbitMQ transport is sending events too slow

### DIFF
--- a/beaver/config.py
+++ b/beaver/config.py
@@ -120,6 +120,9 @@ class BeaverConfig():
             'respawn_delay': '3',
             'max_failure': '7',
 
+            # consumer processes
+            'number_of_consumer_processes': '1',
+
             # interprocess queue max size before puts block
             'max_queue_size': '100',
 
@@ -313,7 +316,8 @@ class BeaverConfig():
                 'logstash_version',
                 'kafka_batch_n',
                 'kafka_batch_t',
-                'kafka_ack_timeout'
+                'kafka_ack_timeout',
+                'number_of_consumer_processes'
             ]
             for key in require_int:
                 if config[key] is not None:

--- a/beaver/run_queue.py
+++ b/beaver/run_queue.py
@@ -31,21 +31,27 @@ def run_queue(queue, beaver_config, logger=None):
                 break
 
             if int(time.time()) - last_update_time > queue_timeout:
-                logger.info('Queue timeout of "{0}" seconds exceeded, stopping queue'.format(queue_timeout))
+                logger.info('Main consumer queue timeout of "{0}" seconds exceeded, stopping queue'.format(queue_timeout))
                 break
 
             try:
                 if queue.full():
-                    logger.debug("Queue is full")
+                    logger.error("Main consumer queue is full")
+
                 else:
-                    logger.debug("Queue Size is: " + str(queue.qsize()))
-                command, data = queue.get(block=True, timeout=wait_timeout)
-                if command == "callback":
-                    last_update_time = int(time.time())
-                    logger.debug('Last update time now {0}'.format(last_update_time))
+                    if count == 1000:
+                        logger.debug("Main consumer queue Size is: " + str(queue.qsize()))
+                        count = 0
+                    command, data = queue.get(block=True, timeout=wait_timeout)
+                    if command == "callback":
+                        last_update_time = int(time.time())
+                        logger.debug('Last update time now {0}'.format(last_update_time))
             except Queue.Empty:
-                logger.debug('No data')
-                continue
+                if not queue.empty():
+                    logger.error('Recieved timeout from main consumer queue - stopping queue')
+                    break
+                else:
+                    logger.debug('No data')
 
             if command == 'callback':
                 if data.get('ignore_empty', False):
@@ -67,15 +73,15 @@ def run_queue(queue, beaver_config, logger=None):
                     try:
                         transport.callback(**data)
                         count += 1
-                        logger.debug("Number of transports: " + str(count))
                         break
-                    except TransportException:
+                    except TransportException,e:
                         failure_count = failure_count + 1
                         if failure_count > beaver_config.get('max_failure'):
                             failure_count = beaver_config.get('max_failure')
 
                         sleep_time = beaver_config.get('respawn_delay') ** failure_count
                         logger.info('Caught transport exception, reconnecting in %d seconds' % sleep_time)
+                        logger.debug(e)
 
                         try:
                             transport.invalidate()

--- a/beaver/run_queue.py
+++ b/beaver/run_queue.py
@@ -17,6 +17,7 @@ def run_queue(queue, beaver_config, logger=None):
     last_update_time = int(time.time())
     queue_timeout = beaver_config.get('queue_timeout')
     wait_timeout = beaver_config.get('wait_timeout')
+    count = 0
 
     transport = None
     try:
@@ -34,6 +35,10 @@ def run_queue(queue, beaver_config, logger=None):
                 break
 
             try:
+                if queue.full():
+                    logger.debug("Queue is full")
+                else:
+                    logger.debug("Queue Size is: " + str(queue.qsize()))
                 command, data = queue.get(block=True, timeout=wait_timeout)
                 if command == "callback":
                     last_update_time = int(time.time())
@@ -61,6 +66,8 @@ def run_queue(queue, beaver_config, logger=None):
                 while True:
                     try:
                         transport.callback(**data)
+                        count += 1
+                        logger.debug("Number of transports: " + str(count))
                         break
                     except TransportException:
                         failure_count = failure_count + 1

--- a/beaver/tests/test_transport_config.py
+++ b/beaver/tests/test_transport_config.py
@@ -15,7 +15,7 @@ class DummyTransport(BaseTransport):
     pass
 
 
-with mock.patch('pika.adapters.BlockingConnection', autospec=True) as mock_pika:
+with mock.patch('pika.adapters.SelectConnection', autospec=True) as mock_pika:
 
     class TransportConfigTests(unittest.TestCase):
         def setUp(self):
@@ -25,7 +25,7 @@ with mock.patch('pika.adapters.BlockingConnection', autospec=True) as mock_pika:
             empty_conf = tempfile.NamedTemporaryFile(delete=True)
             return BeaverConfig(mock.Mock(config=empty_conf.name, **kwargs))
 
-        @mock.patch('pika.adapters.BlockingConnection', mock_pika)
+        @mock.patch('pika.adapters.SelectConnection', mock_pika)
         def test_builtin_rabbitmq(self):
             beaver_config = self._get_config(transport='rabbitmq')
             transport = create_transport(beaver_config, logger=self.logger)

--- a/beaver/transports/rabbitmq_transport.py
+++ b/beaver/transports/rabbitmq_transport.py
@@ -86,8 +86,10 @@ class RabbitmqTransport(BaseTransport):
 
 
 
-    def _on_connection_open_error(self):
+    def _on_connection_open_error(self,non_used_connection=None,error=None):
         self._logger.debug("connection open error")
+        if not error==None:
+            self._logger.error(error)
 
     def _on_connection_closed(self, connection, reply_code, reply_text):
         self._channel = None
@@ -110,7 +112,11 @@ class RabbitmqTransport(BaseTransport):
 
     def _connection_start(self):
         self._logger.debug("Creating Connection")
-        self._connection = pika.adapters.SelectConnection(parameters=self._parameters,on_open_callback=self._on_connection_open,on_open_error_callback=self._on_connection_open_error,on_close_callback=self._on_connection_closed,stop_ioloop_on_close=False)
+        try:
+            self._connection = pika.adapters.SelectConnection(parameters=self._parameters,on_open_callback=self._on_connection_open,on_open_error_callback=self._on_connection_open_error,on_close_callback=self._on_connection_closed,stop_ioloop_on_close=False)
+        except Exception,e:
+            self._logger.error("Failed Creating RabbitMQ connection")
+            self._logger.error(e)
         self._logger.debug("Starting ioloop")
         self._connection.ioloop.start()
 

--- a/beaver/transports/rabbitmq_transport.py
+++ b/beaver/transports/rabbitmq_transport.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
+from Queue import Queue
 import pika
 import ssl
+from threading import Thread
+import time
 
 from beaver.transports.base_transport import BaseTransport
 from beaver.transports.exception import TransportException
@@ -23,7 +26,93 @@ class RabbitmqTransport(BaseTransport):
 
         self._connection = None
         self._channel = None
+        self._count = 0
+        self._lines = Queue()
         self._connect()
+
+    def _on_connection_open(self,connection):
+        self._logger.debug("connection created")
+        self._channel = connection.channel(self._on_channel_open)
+
+    def _on_channel_open(self,unused):
+        self._logger.debug("Channel Created")
+        self._channel.exchange_declare(self._on_exchange_declareok,
+                                       exchange=self._rabbitmq_config['exchange'],
+                                       exchange_type=self._rabbitmq_config['exchange_type'],
+                                       durable=self._rabbitmq_config['exchange_durable'])
+
+    def _on_exchange_declareok(self,unused):
+        self._logger.debug("Exchange Declared")
+        self._channel.queue_declare(self._on_queue_declareok,
+                                    queue=self._rabbitmq_config['queue'],
+                                    durable=self._rabbitmq_config['queue_durable'],
+                                    arguments={'x-ha-policy': 'all'} if self._rabbitmq_config['ha_queue'] else {})
+
+    def _on_queue_declareok(self,unused):
+        self._logger.debug("Queue Declared")
+        self._channel.queue_bind(self._on_bindok,
+                                 exchange=self._rabbitmq_config['exchange'],
+                                 queue=self._rabbitmq_config['queue'],
+                                 routing_key=self._rabbitmq_config['key'])
+
+    def _on_bindok(self,unused):
+        self._logger.debug("Exchange to Queue Bind OK")
+        self._is_valid = True;
+        self._logger.debug("Scheduling next message for %0.1f seconds",1)
+        self._connection.add_timeout(1,self._publish_message)
+
+
+    def _publish_message(self):
+        while True:
+            self._count += 0
+            if self._lines.not_empty:
+                line = self._lines.get()
+                if self._count == 10000:
+                    self._logger.debug("RabbitMQ transport queue size: %s" % (self._lines.qsize(), ))
+                    self._count = 0
+                else:
+                    self._count += 1
+                self._channel.basic_publish(
+                        exchange=self._rabbitmq_config['exchange'],
+                        routing_key=self._rabbitmq_config['key'],
+                        body=line,
+                        properties=pika.BasicProperties(
+                            content_type='text/json',
+                            delivery_mode=self._rabbitmq_config['delivery_mode']
+                        ))
+            else:
+                self._logger.debug("RabbitMQ transport queue is empty, sleeping for 1 second.")
+                time.sleep(1)
+
+
+
+    def _on_connection_open_error(self):
+        self._logger.debug("connection open error")
+
+    def _on_connection_closed(self, connection, reply_code, reply_text):
+        self._channel = None
+        if self._connection._closing:
+            try:
+                self._connection.ioloop.stop()
+            except:
+                pass
+        else:
+            self._logger.warning('RabbitMQ Connection closed, reopening in 1 seconds: (%s) %s',
+                           reply_code, reply_text)
+            self._connection.add_timeout(1, self.reconnect)
+
+    def reconnect(self):
+        try:
+            self._connection.ioloop.stop()
+        except:
+            pass
+        self._connection_start()
+
+    def _connection_start(self):
+        self._logger.debug("Creating Connection")
+        self._connection = pika.adapters.SelectConnection(parameters=self._parameters,on_open_callback=self._on_connection_open,on_open_error_callback=self._on_connection_open_error,on_close_callback=self._on_connection_closed,stop_ioloop_on_close=False)
+        self._logger.debug("Starting ioloop")
+        self._connection.ioloop.start()
 
     def _connect(self):
 
@@ -38,7 +127,7 @@ class RabbitmqTransport(BaseTransport):
             'ca_certs': self._rabbitmq_config['ssl_cacert'],
             'ssl_version': ssl.PROTOCOL_TLSv1
         }
-        parameters = pika.connection.ConnectionParameters(
+        self._parameters = pika.connection.ConnectionParameters(
             credentials=credentials,
             host=self._rabbitmq_config['host'],
             port=self._rabbitmq_config['port'],
@@ -46,47 +135,19 @@ class RabbitmqTransport(BaseTransport):
             ssl_options=ssl_options,
             virtual_host=self._rabbitmq_config['vhost']
         )
-        self._connection = pika.adapters.BlockingConnection(parameters)
-        self._channel = self._connection.channel()
-
-        # Declare RabbitMQ queue and bindings
-        self._channel.queue_declare(
-            queue=self._rabbitmq_config['queue'],
-            durable=self._rabbitmq_config['queue_durable'],
-            arguments={'x-ha-policy': 'all'} if self._rabbitmq_config['ha_queue'] else {}
-        )
-        self._channel.exchange_declare(
-            exchange=self._rabbitmq_config['exchange'],
-            exchange_type=self._rabbitmq_config['exchange_type'],
-            durable=self._rabbitmq_config['exchange_durable']
-        )
-        self._channel.queue_bind(
-            exchange=self._rabbitmq_config['exchange'],
-            queue=self._rabbitmq_config['queue'],
-            routing_key=self._rabbitmq_config['key']
-        )
-
-        self._is_valid = True;
+        Thread(target=self._connection_start).start()
 
     def callback(self, filename, lines, **kwargs):
         timestamp = self.get_timestamp(**kwargs)
         if kwargs.get('timestamp', False):
             del kwargs['timestamp']
-
         for line in lines:
             try:
                 import warnings
                 with warnings.catch_warnings():
                     warnings.simplefilter('error')
-                    self._channel.basic_publish(
-                        exchange=self._rabbitmq_config['exchange'],
-                        routing_key=self._rabbitmq_config['key'],
-                        body=self.format(filename, line, timestamp, **kwargs),
-                        properties=pika.BasicProperties(
-                            content_type='text/json',
-                            delivery_mode=self._rabbitmq_config['delivery_mode']
-                        )
-                    )
+                    body = self.format(filename, line, timestamp, **kwargs)
+                    self._lines.put(body)
             except UserWarning:
                 self._is_valid = False
                 raise TransportException('Connection appears to have been lost')
@@ -100,9 +161,6 @@ class RabbitmqTransport(BaseTransport):
     def interrupt(self):
         if self._connection:
             self._connection.close()
-
-    def reconnect(self):
-        self._connect()
 
     def unhandled(self):
         return True


### PR DESCRIPTION
This fix includes two part:
1. I added a log print in debug mode that shows the size of the Queue and a count of the number of transports that were performed in order to be able to find if the problem with delivery rates is in adding events to the queue or sending them with the defined transport.

2. I added a new configuration variable that allows to run more than one consumer process per Queue in order to increase the performance of the transport.

Please let me know if you have any questions or remarks - from the tests I ran in my environment using the rabbitMQ trasport (sends around 6500 log entries per second), increasing the number of consumers really helped.