### PR TITLE
fix tests when ZMQ is not installed

### DIFF
--- a/beaver/tests/test_transport_config.py
+++ b/beaver/tests/test_transport_config.py
@@ -10,6 +10,14 @@ from beaver.config import BeaverConfig
 from beaver.transports import create_transport
 from beaver.transports.base_transport import BaseTransport
 
+try:
+    from beaver.transports.zmq_transport import ZmqTransport
+    zmqSkip = False
+except ImportError, e:
+    if e.message == 'No module named zmq':
+        zmqSkip = True
+    else:
+        raise
 
 class DummyTransport(BaseTransport):
     pass
@@ -47,10 +55,11 @@ with mock.patch('pika.adapters.BlockingConnection', autospec=True) as mock_pika:
             transport = create_transport(beaver_config, logger=self.logger)
             self.assertIsInstance(transport, beaver.transports.udp_transport.UdpTransport)
 
+        @unittest.skipIf(zmqSkip, 'zmq not installed')
         def test_builtin_zmq(self):
             beaver_config = self._get_config(transport='zmq')
             transport = create_transport(beaver_config, logger=self.logger)
-            self.assertIsInstance(transport, beaver.transports.zmq_transport.ZmqTransport)
+            self.assertIsInstance(transport, ZmqTransport)
 
         def test_custom_transport(self):
             beaver_config = self._get_config(transport='beaver.tests.test_transport_config.DummyTransport')


### PR DESCRIPTION
when I run tests with no ZMQ installed, I end up with following error

```
======================================================================
ERROR: test_builtin_zmq (beaver.tests.test_transport_config.TransportConfigTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/dejv/Workspace/beaver/python-beaver/beaver/tests/test_transport_config.py", line 52, in test_builtin_zmq
    transport = create_transport(beaver_config, logger=self.logger)
  File "/home/dejv/Workspace/beaver/python-beaver/beaver/transports/__init__.py", line 18, in create_transport
    _module = __import__(module_path, globals(), locals(), class_name, -1)
  File "/home/dejv/Workspace/beaver/python-beaver/beaver/transports/zmq_transport.py", line 2, in <module>
    import zmq
ImportError: No module named zmq
```

it should be fixed the same way as here: https://github.com/josegonzalez/python-beaver/blob/master/beaver/tests/test_zmq_transport.py#L8