### PR TITLE
fix tests for python 2.7 (add funcsigs test dependency)

### DIFF
--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,4 +1,5 @@
 fakeredis>=0.4.1
+funcsigs
 mock
 nose
 six


### PR DESCRIPTION
need to add funcsigs test dependency for python 2.7, due to breaking changes in a mock library https://github.com/testing-cabal/mock/issues/262