### PR TITLE
Ensure log lines confirm to utf-8 standard

### DIFF
--- a/beaver/transports/base_transport.py
+++ b/beaver/transports/base_transport.py
@@ -116,6 +116,7 @@ class BaseTransport(object):
 
     def format(self, filename, line, timestamp, **kwargs):
         """Returns a formatted log line"""
+        line = unicode(line.encode("utf-8")[:32766], "utf-8", errors="ignore")
         formatter = self._beaver_config.get_field('format', filename)
         if formatter not in self._formatters:
             formatter = self._default_formatter


### PR DESCRIPTION
We've come across cases when certain characters break Beaver transmitting log lines. This PR ensures all log lines correctly conform to UTF-8 when they're formatted for transmission.