### PR TITLE
Ensure tests pass on Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: python
 python:
+  - "2.6"
   - "2.7"
 addons:
   apt:

--- a/beaver/tests/test_glob_sections.py
+++ b/beaver/tests/test_glob_sections.py
@@ -1,5 +1,10 @@
 # -*- coding: utf-8 -*-
-import unittest 
+import sys
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
+
 import os
 import glob
 from beaver.config import BeaverConfig

--- a/beaver/tests/test_kafka_transport.py
+++ b/beaver/tests/test_kafka_transport.py
@@ -1,6 +1,11 @@
 # -*- coding: utf-8 -*-
+import sys
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
+
 import mock
-import unittest
 import tempfile
 import logging
 

--- a/beaver/tests/test_transport_config.py
+++ b/beaver/tests/test_transport_config.py
@@ -1,9 +1,14 @@
 # -*- coding: utf-8 -*-
+import sys
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
+
 import fakeredis
 import logging
 import mock
 import tempfile
-import unittest
 
 import beaver
 from beaver.config import BeaverConfig

--- a/beaver/tests/test_zmq_transport.py
+++ b/beaver/tests/test_zmq_transport.py
@@ -1,6 +1,11 @@
 # -*- coding: utf-8 -*-
+import sys
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
+
 import mock
-import unittest
 import tempfile
 
 from beaver.config import BeaverConfig

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -3,3 +3,4 @@ funcsigs
 mock
 nose
 six
+unittest2


### PR DESCRIPTION
README states we support 2.6, but the tests only run against 2.7...